### PR TITLE
Feature unix rspec support

### DIFF
--- a/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
+++ b/lib/puppet/provider/dsc_base_provider/dsc_base_provider.rb
@@ -1076,6 +1076,10 @@ class Puppet::Provider::DscBaseProvider # rubocop:disable Metrics/ClassLength
   def ps_manager
     debug_output = Puppet::Util::Log.level == :debug
     # TODO: Allow you to specify an alternate path, either to pwsh generally or a specific pwsh path.
-    Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args, debug: debug_output)
+    if Pwsh::Util.on_windows?
+      Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args, debug: debug_output)
+    else
+      Pwsh::Manager.instance(Pwsh::Manager.pwsh_path, Pwsh::Manager.pwsh_args, debug: debug_output)
+    end
   end
 end

--- a/lib/pwsh.rb
+++ b/lib/pwsh.rb
@@ -380,7 +380,7 @@ module Pwsh
           pwsh_paths << File.join(path, 'pwsh.exe') if File.exist?(File.join(path, 'pwsh.exe'))
         end
       else
-        search_paths.split(File::PATH_SEPARATOR).each do |path|
+        search_paths.split(':').each do |path|
           pwsh_paths << File.join(path, 'pwsh') if File.exist?(File.join(path, 'pwsh'))
         end
       end

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -12,7 +12,9 @@ module Pwsh
     def on_windows?
       # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
       # library uses that to test what platform it's on.
-      !!File::ALT_SEPARATOR
+      require 'rbconfig'
+      is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+      !!is_windows
     end
 
     # Verify paths specified are valid directories which exist.

--- a/lib/pwsh/util.rb
+++ b/lib/pwsh/util.rb
@@ -7,14 +7,12 @@ module Pwsh
     module_function
 
     # Verifies whether or not the current context is running on a Windows node.
+    # Implementation copied from `facets`: https://github.com/rubyworks/facets/blob/main/lib/standard/facets/rbconfig.rb
     #
     # @return [Bool] true if on windows
     def on_windows?
-      # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
-      # library uses that to test what platform it's on.
-      require 'rbconfig'
-      is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-      !!is_windows
+      host_os = RbConfig::CONFIG['host_os']
+      !!(host_os =~ /mswin|mingw/)
     end
 
     # Verify paths specified are valid directories which exist.

--- a/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
+++ b/spec/unit/puppet/provider/dsc_base_provider/dsc_base_provider_spec.rb
@@ -2110,21 +2110,44 @@ RSpec.describe Puppet::Provider::DscBaseProvider do
   end
 
   describe '.ps_manager' do
-    before do
-      allow(Pwsh::Manager).to receive(:powershell_path).and_return('pwsh')
-      allow(Pwsh::Manager).to receive(:powershell_args).and_return('args')
+    describe '.ps_manager on non-Windows' do
+      before do
+        allow(Pwsh::Util).to receive(:on_windows?).and_return(false)
+        allow(Pwsh::Manager).to receive(:pwsh_path).and_return('pwsh')
+        allow(Pwsh::Manager).to receive(:pwsh_args).and_return('args')
+      end
+
+      it 'Initializes an instance of the Pwsh::Manager' do
+        expect(Puppet::Util::Log).to receive(:level).and_return(:normal)
+        expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: false)
+        expect { provider.ps_manager }.not_to raise_error
+      end
+
+      it 'passes debug as true if Puppet::Util::Log.level is debug' do
+        expect(Puppet::Util::Log).to receive(:level).and_return(:debug)
+        expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: true)
+        expect { provider.ps_manager }.not_to raise_error
+      end
     end
 
-    it 'Initializes an instance of the Pwsh::Manager' do
-      expect(Puppet::Util::Log).to receive(:level).and_return(:normal)
-      expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: false)
-      expect { provider.ps_manager }.not_to raise_error
-    end
+    describe '.ps_manager on Windows' do
+      before do
+        allow(Pwsh::Util).to receive(:on_windows?).and_return(true)
+        allow(Pwsh::Manager).to receive(:powershell_path).and_return('pwsh')
+        allow(Pwsh::Manager).to receive(:powershell_args).and_return('args')
+      end
 
-    it 'passes debug as true if Puppet::Util::Log.level is debug' do
-      expect(Puppet::Util::Log).to receive(:level).and_return(:debug)
-      expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: true)
-      expect { provider.ps_manager }.not_to raise_error
+      it 'Initializes an instance of the Pwsh::Manager' do
+        expect(Puppet::Util::Log).to receive(:level).and_return(:normal)
+        expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: false)
+        expect { provider.ps_manager }.not_to raise_error
+      end
+
+      it 'passes debug as true if Puppet::Util::Log.level is debug' do
+        expect(Puppet::Util::Log).to receive(:level).and_return(:debug)
+        expect(Pwsh::Manager).to receive(:instance).with('pwsh', 'args', debug: true)
+        expect { provider.ps_manager }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Add support for spec testing DSC resources that leverage the dsc_base_provider on non-windows OS using pwsh. 

## Requirements
- PowerShell or Pwsh must be installed on the OS executing the spec tests.
  (See https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.4)
- $PSHOME (PowerShell Home) must be added to the $PATH system variable to ensure the provider can discover and execute `pwsh`.

 
## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
  - The dsc_base_provider implements a feature called canonicalize.
    - Canonicalize attempts to query the current state of DSC resources on a target node whilst the catalog is being compiled
    - This attempts to avoid unnecessary corrective changes by ruling out changes due to case-sensitivity of resources in the manifest. 
  - During a spec test, the ruby interpreter attempts to compile a catalog which triggers the canonicalize feature
    - The ruby interpreter attempts to open PowerShell via a named pipe on the OS running the spec test
    - PowerShell runs Invoke-dscresource using the Get method to query the local state of the synthetic node. 
    - As the synthetic node is actually the OS running the spec test, the commandlet returns no existing DSC resources and the catalog uses the values in the manifest as source of truth
    -  This means PowerShell or pwsh must be installed on the test hardware to support the canonicalize feature of catalog compilation.

Issues
  - The dsc_base_provider currently only attempts to run PowerShell from Windows directories and does not check for Pwsh within Unix paths.
  - The ruby interpreter is fooled into thinking its always running on Windows due to the File::ALT_SEPARATOR being set via the context OS set by puppet-rspec-facts. This prevents the Pwsh::Util.on_windows? method from correctly identifying the OS running the spec test and following the appropriate conditional paths for non-Windows. 
  
  
Updates Required
- Update Pwsh::Util.on_windows? method to query the rbconfig for the Ruby env OS instead of the file constant File::ALT_SEPARATOR.  
  - The constant is unreliable for determining the OS running the ruby interpreter. 
- Update ps_manager within the dsc_base_provider to use pwsh for non-windows. 

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
